### PR TITLE
Fix for enivorment file changing version of the libgfortran package from 5.0.0 to 3.0.0 to work on non OSX platforms. See issue #1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - libcxx=14.0.6
   - libdeflate=1.22
   - libffi=3.4.4
-  - libgfortran=5.0.0
+  - libgfortran=3.0.0
   - libgfortran5=11.3.0
   - libopenblas=0.3.21
   - libpng=1.6.39


### PR DESCRIPTION
version change from 5.0.0 to 3.0.0 to accomodate non OSX machines